### PR TITLE
Make player control panel receive tournament round

### DIFF
--- a/dashboard/PlayerControlPanel.js
+++ b/dashboard/PlayerControlPanel.js
@@ -163,7 +163,7 @@ $(function () {
         });
     });
 
-	nodecg.listenFor('smashgg-setplayersactive', function(value, callback) {
+    nodecg.listenFor('smashgg-setplayersactive', function(value, callback) {
         $player1DropdownMenu.val(value.p1.gamerTag);
         $player2DropdownMenu.val(value.p2.gamerTag);
         $player1Score.val(0);
@@ -172,5 +172,9 @@ $(function () {
         $player2Flag.val(value.p2.flag);
 
         updateMatchStats();
-	});
+    });
+
+    nodecg.listenFor('smashgg-sendrounddata', function(value, callback) {
+        $tournamentRound.val(value);
+    });
 })

--- a/dashboard/SmashGGControlPanel.js
+++ b/dashboard/SmashGGControlPanel.js
@@ -284,6 +284,7 @@ $(function () {
             var players = b.entities.player;
             nodecg.sendMessage("smashgg-sendplayerdata", players);
             sets.forEach(function (item) {
+                item.fullRoundText = item.fullRoundText.replace('-Final', 's').replace(' Final', ' Finals');
                 var player1 = $.grep(players, function (e) { return e.entrantId == item.entrant1Id; })[0];
                 var player2 = $.grep(players, function (e) { return e.entrantId == item.entrant2Id; })[0];
 


### PR DESCRIPTION
Also replace the smash.gg round names (Winners Semi-Final, Winners Final, ...) to round names that most streamers use (Winners Semis, Winners Finals, ...).